### PR TITLE
fix(release): package qa under bin for brew installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,19 +62,19 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           mkdir -p dist
-          mkdir -p package
-          cp dist/qa "package/qa"
-          chmod +x package/qa
-          tar -czf "dist/${{ matrix.artifact_name }}" -C package .
+          mkdir -p "package/qa-${{ matrix.id }}/bin"
+          cp dist/qa "package/qa-${{ matrix.id }}/bin/qa"
+          chmod +x "package/qa-${{ matrix.id }}/bin/qa"
+          tar -czf "dist/${{ matrix.artifact_name }}" -C package "qa-${{ matrix.id }}"
 
       - name: Package executable (macOS)
         if: runner.os == 'macOS'
         run: |
           mkdir -p dist
-          mkdir -p package
-          cp dist/qa "package/qa"
-          chmod +x package/qa
-          (cd package && zip -r "../dist/${{ matrix.artifact_name }}" .)
+          mkdir -p "package/qa-${{ matrix.id }}/bin"
+          cp dist/qa "package/qa-${{ matrix.id }}/bin/qa"
+          chmod +x "package/qa-${{ matrix.id }}/bin/qa"
+          (cd package && zip -r "../dist/${{ matrix.artifact_name }}" "qa-${{ matrix.id }}")
 
       - name: Package executable (Windows)
         if: runner.os == 'Windows'
@@ -116,7 +116,7 @@ jobs:
 
       - name: Verify packaged artifacts layout
         run: |
-          python -c "import zipfile, tarfile; norm=lambda s:s.lstrip('./'); t=tarfile.open('dist/qa-linux-amd64.tar.gz','r:gz'); n=[norm(x) for x in t.getnames()]; t.close(); assert 'qa' in n, f'qa missing in linux tar: {n}'; z=zipfile.ZipFile('dist/qa-macos-arm64.zip','r'); n=[norm(x) for x in z.namelist()]; z.close(); assert 'qa' in n, f'qa missing in mac zip: {n}'; z=zipfile.ZipFile('dist/qa-windows-amd64.zip','r'); n=[norm(x) for x in z.namelist()]; z.close(); assert any(x.endswith('bin/qa.exe') for x in n), f'bin/qa.exe missing in windows zip: {n}'"
+          python -c "import zipfile, tarfile; norm=lambda s:s.lstrip('./'); t=tarfile.open('dist/qa-linux-amd64.tar.gz','r:gz'); n=[norm(x) for x in t.getnames()]; t.close(); assert any(x.endswith('bin/qa') for x in n), f'bin/qa missing in linux tar: {n}'; z=zipfile.ZipFile('dist/qa-macos-arm64.zip','r'); n=[norm(x) for x in z.namelist()]; z.close(); assert any(x.endswith('bin/qa') for x in n), f'bin/qa missing in mac zip: {n}'; z=zipfile.ZipFile('dist/qa-windows-amd64.zip','r'); n=[norm(x) for x in z.namelist()]; z.close(); assert any(x.endswith('bin/qa.exe') for x in n), f'bin/qa.exe missing in windows zip: {n}'"
 
       - name: Setup Java for JReleaser
         uses: actions/setup-java@v4

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -39,6 +39,8 @@ distributions:
     artifacts:
       - path: dist/qa-linux-amd64.tar.gz
         platform: linux-x86_64
+      - path: dist/qa-linux-arm64.tar.gz
+        platform: linux-aarch_64
       - path: dist/qa-macos-arm64.zip
         platform: osx-aarch_64
       - path: dist/qa-windows-amd64.zip


### PR DESCRIPTION
## What
- Adjust Linux/macOS packaging to include `bin/qa` inside release artifacts.
- Update artifact layout verification to assert `bin/qa` on Unix and `bin/qa.exe` on Windows.
- Add Linux ARM64 artifact in `jreleaser.yml` distribution list.
## Why
Homebrew formula symlinks `#{libexec}/bin/qa`; when artifacts ship `qa` at root, `brew install qa` ends with `qa` not found on macOS.