### PR TITLE
feat: add mcp server and async ai analysis flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,21 +158,50 @@ uv sync
 uv run qa-api
 ```
 
-El servidor escucha por defecto en `http://127.0.0.1:8001`.
+El servidor escucha por defecto en `http://127.0.0.1:8000`. Puedes cambiar host
+y puerto con `QA_API_HOST` y `QA_API_PORT`; por ejemplo,
+`$env:QA_API_PORT="8001"; uv run qa-api`.
 
-- Swagger UI: `http://127.0.0.1:8001/docs`
-- OpenAPI: `http://127.0.0.1:8001/openapi.json`
+- Swagger UI: `http://127.0.0.1:8000/docs`
+- OpenAPI: `http://127.0.0.1:8000/openapi.json`
 - Base de endpoints: `/api/v1/analyzer`
 
 Ejemplo con SQLite:
 
 ```bash
-curl -X POST http://127.0.0.1:8001/api/v1/analyzer/explain \
+curl -X POST http://127.0.0.1:8000/api/v1/analyzer/explain \
   -H "Content-Type: application/json" \
   -d '{"connection":{"engine":"sqlite","database":":memory:"},"query":"SELECT 1"}'
 ```
 
 Consulta [docs/API.md](docs/API.md) para los contratos y endpoints disponibles.
+
+## Servidor MCP
+
+Query Analyzer expone una herramienta MCP para agentes de programación. El
+servidor usa los perfiles locales de `qa profile` y ejecuta el análisis contra
+el core del proyecto, sin requerir que la API FastAPI esté encendida.
+
+```bash
+uv sync
+uv run python -m query_analyzer.mcp_server
+```
+
+Configuración ejemplo para clientes MCP por stdio:
+
+```json
+{
+  "mcpServers": {
+    "query_analyzer": {
+      "command": "uv",
+      "args": ["run", "python", "-m", "query_analyzer.mcp_server"]
+    }
+  }
+}
+```
+
+La tool disponible es `analyze_query(query, profile)`. Si `profile` se omite,
+se usa el perfil por defecto configurado en Query Analyzer.
 
 ## AI Integration (v2.1.0+)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,9 +13,13 @@ uv run qa-api
 
 Direcciones locales:
 
-- API: `http://127.0.0.1:8001/api/v1`
-- Swagger UI: `http://127.0.0.1:8001/docs`
-- OpenAPI: `http://127.0.0.1:8001/openapi.json`
+- API: `http://127.0.0.1:8000/api/v1`
+- Swagger UI: `http://127.0.0.1:8000/docs`
+- OpenAPI: `http://127.0.0.1:8000/openapi.json`
+
+El host y puerto se pueden configurar con `QA_API_HOST` y `QA_API_PORT`. Por
+compatibilidad local, `QA_API_PORT=8001` conserva la dirección usada en versiones
+anteriores.
 
 ## Endpoints
 
@@ -50,7 +54,7 @@ no devuelven excepciones de drivers ni valores de conexión.
 ## EXPLAIN
 
 ```bash
-curl -X POST http://127.0.0.1:8001/api/v1/analyzer/explain \
+curl -X POST http://127.0.0.1:8000/api/v1/analyzer/explain \
   -H "Content-Type: application/json" \
   -d '{"connection":{"engine":"sqlite","database":":memory:"},"query":"SELECT 1"}'
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
     "elasticsearch>=8.0.0,<9.0.0",
     "fastapi>=0.111.0",
     "uvicorn[standard]>=0.29.0",
+    "mcp>=1.27,<2",
+    "requests>=2.32.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/query_analyzer/api/app.py
+++ b/query_analyzer/api/app.py
@@ -1,5 +1,7 @@
 """FastAPI application for Query Analyzer."""
 
+import os
+
 import uvicorn
 from fastapi import FastAPI
 
@@ -16,7 +18,9 @@ app.include_router(router, prefix="/api/v1")
 
 def main() -> None:
     """Run the API server on the local development address."""
-    uvicorn.run("query_analyzer.api.app:app", host="127.0.0.1", port=8001)
+    host = os.environ.get("QA_API_HOST", "127.0.0.1")
+    port = int(os.environ.get("QA_API_PORT", "8000"))
+    uvicorn.run("query_analyzer.api.app:app", host=host, port=port)
 
 
 if __name__ == "__main__":

--- a/query_analyzer/api/router.py
+++ b/query_analyzer/api/router.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi import APIRouter
 
 from query_analyzer.adapters import AdapterRegistry
-from query_analyzer.adapters.models import ConnectionConfig
+from query_analyzer.adapters.models import AIAnalysisResult, ConnectionConfig, QueryAnalysisReport
 from query_analyzer.core import AIAnalyzer
 from query_analyzer.core.connection_diagnostics import ConnectionDiagnosticsService
 
@@ -61,6 +61,34 @@ def _log_api_error(
     logger.error("API operation %s failed: %s", operation, detail)
 
 
+def _run_optional_ai_analysis(report: QueryAnalysisReport) -> AIAnalysisResult | None:
+    """Run configured AI analysis without making factual EXPLAIN depend on it."""
+    try:
+        analyzer = AIAnalyzer()
+        if not analyzer.available:
+            return None
+
+        result = analyzer.analyze(
+            plan_json=report.raw_plan or report.plan_summary or "No plan available",
+            query=report.query,
+            engine=report.engine,
+        )
+
+        if result is None:
+            return None
+
+        return AIAnalysisResult(
+            summary=result.summary,
+            observations=result.observations,
+            recommendations=result.recommendations,
+            suggested_query=result.suggested_query,
+            raw_response=result.raw_response,
+        )
+    except Exception as error:
+        _log_api_error("explain-ai", error)
+        return None
+
+
 @router.get("/engines")
 def list_engines() -> dict[str, list[str]]:
     """Lista todos los motores de BD soportados."""
@@ -77,6 +105,9 @@ def analyze_query(req: AnalyzeRequest) -> AnalyzeResponse:
 
         with adapter:
             report = adapter.execute_explain(req.query)
+
+        if req.include_ai:
+            report.ai_analysis = _run_optional_ai_analysis(report)
 
         return AnalyzeResponse(
             success=True,
@@ -104,10 +135,15 @@ def analyze_query(req: AnalyzeRequest) -> AnalyzeResponse:
 def ai_analyze(req: AIAnalyzeRequest) -> AIAnalyzeResponse:
     """Analiza un plan EXPLAIN usando IA."""
     try:
-        analyzer = AIAnalyzer(
-            base_url=req.ai_config.base_url,
-            api_key=req.ai_config.api_key.get_secret_value(),
-            model=req.ai_config.model,
+        api_key = req.ai_config.api_key.get_secret_value() if req.ai_config else ""
+        analyzer = (
+            AIAnalyzer(
+                base_url=req.ai_config.base_url,
+                api_key=api_key,
+                model=req.ai_config.model,
+            )
+            if req.ai_config
+            else AIAnalyzer()
         )
 
         if not analyzer.available:
@@ -126,7 +162,8 @@ def ai_analyze(req: AIAnalyzeRequest) -> AIAnalyzeResponse:
             suggested_query=result.suggested_query,
         )
     except Exception as error:
-        _log_api_error("ai", error, secrets=(req.ai_config.api_key.get_secret_value(),))
+        secrets = (req.ai_config.api_key.get_secret_value(),) if req.ai_config else ()
+        _log_api_error("ai", error, secrets=secrets)
         return AIAnalyzeResponse(success=False, error="No se pudo completar el análisis con IA.")
 
 

--- a/query_analyzer/api/schemas.py
+++ b/query_analyzer/api/schemas.py
@@ -26,6 +26,10 @@ class AnalyzeRequest(BaseModel):
 
     connection: ConnectionRequest
     query: str = Field(..., description="Consulta SQL/NoSQL a analizar")
+    include_ai: bool = Field(
+        default=False,
+        description="Ejecutar análisis de IA en la misma respuesta. Por defecto es falso para no bloquear el EXPLAIN factual.",
+    )
 
 
 class AIConfigRequest(BaseModel):
@@ -42,7 +46,7 @@ class AIAnalyzeRequest(BaseModel):
     plan_json: Any = Field(..., description="Plan de ejecución (dict o string)")
     query: str = Field(..., description="Consulta original")
     engine: str = Field(..., description="Motor de BD")
-    ai_config: AIConfigRequest
+    ai_config: AIConfigRequest | None = None
 
 
 class MetricsRequest(BaseModel):

--- a/query_analyzer/mcp_server.py
+++ b/query_analyzer/mcp_server.py
@@ -1,0 +1,79 @@
+"""MCP server exposing Query Analyzer tools."""
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from query_analyzer.adapters import AdapterRegistry
+from query_analyzer.config import ConfigManager
+
+mcp = FastMCP("Query Analyzer", json_response=True)
+
+
+def _resolve_connection_profile(profile: str | None) -> tuple[str, Any]:
+    """Resolve the requested profile name and return its connection config."""
+    config_manager = ConfigManager()
+    app_config = config_manager.load_config()
+    profile_name = profile or app_config.default_profile
+
+    if not profile_name:
+        raise ValueError(
+            "No profile provided and no default profile configured. "
+            "Create one with `qa profile add` or pass the profile argument."
+        )
+
+    return profile_name, config_manager.get_connection_config(profile_name)
+
+
+def analyze_query_with_profile(query: str, profile: str | None = None) -> dict[str, Any]:
+    """Analyze a query using a configured Query Analyzer profile."""
+    if not query.strip():
+        return {
+            "success": False,
+            "engine": "",
+            "query": query,
+            "error": "Query cannot be empty.",
+        }
+
+    try:
+        profile_name, connection_config = _resolve_connection_profile(profile)
+        adapter = AdapterRegistry.create(connection_config.engine, connection_config)
+
+        with adapter:
+            report = adapter.execute_explain(query)
+
+        data = report.model_dump(mode="json")
+        return {
+            "success": True,
+            "profile": profile_name,
+            "engine": data["engine"],
+            "query": data["query"],
+            "execution_time_ms": data["execution_time_ms"],
+            "plan_summary": data["plan_summary"],
+            "metrics": data["metrics"],
+            "raw_plan": data["raw_plan"],
+            "analyzed_at": data["analyzed_at"],
+            "error": None,
+        }
+    except Exception as error:
+        return {
+            "success": False,
+            "engine": "",
+            "query": query,
+            "error": str(error),
+        }
+
+
+@mcp.tool()
+def analyze_query(query: str, profile: str | None = None) -> dict[str, Any]:
+    """Analyze database query performance using a Query Analyzer profile."""
+    return analyze_query_with_profile(query=query, profile=profile)
+
+
+def main() -> None:
+    """Run the Query Analyzer MCP server over stdio."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/query_analyzer/tui/screens/analysis_screen.py
+++ b/query_analyzer/tui/screens/analysis_screen.py
@@ -11,7 +11,7 @@ from textual.screen import Screen
 from textual.widgets import Button, Footer, Static, TabbedContent, TabPane
 
 from query_analyzer.adapters import QueryAnalysisError
-from query_analyzer.adapters.models import QueryAnalysisReport
+from query_analyzer.adapters.models import AIAnalysisResult, QueryAnalysisReport
 from query_analyzer.cli.commands.analyze import validate_query
 from query_analyzer.tui.connection_state import ConnectionManager
 from query_analyzer.tui.history_manager import AnalysisRecord, get_history_manager
@@ -447,34 +447,7 @@ class AnalysisScreen(Screen[None]):
 
             report = adapter.execute_explain(query_text)
 
-            # AI Analysis integration
-            ai_error = None
-            try:
-                from query_analyzer.core.ai_analyzer import AIAnalyzer
-
-                ai_analyzer = AIAnalyzer()
-                if ai_analyzer.available:
-                    ai_result = ai_analyzer.analyze(
-                        plan_json=report.raw_plan or report.plan_summary or "No plan available",
-                        query=report.query,
-                        engine=report.engine,
-                    )
-                    if ai_result:
-                        from query_analyzer.adapters.models import (
-                            AIAnalysisResult as ModelAIAnalysisResult,
-                        )
-
-                        report.ai_analysis = ModelAIAnalysisResult(
-                            summary=ai_result.summary,
-                            observations=ai_result.observations,
-                            recommendations=ai_result.recommendations,
-                            suggested_query=ai_result.suggested_query,
-                            raw_response=ai_result.raw_response,
-                        )
-            except Exception as e:
-                ai_error = str(e)
-
-            self.app.call_from_thread(self._on_analysis_success, query_text, report, ai_error)
+            self.app.call_from_thread(self._on_analysis_success, query_text, report, None)
         except Exception as error:
             self.app.call_from_thread(self._on_analysis_error, str(error))
 
@@ -505,6 +478,66 @@ class AnalysisScreen(Screen[None]):
         self.query_one(QueryEditor).set_busy(False)
         self.query_one("#btn-analyze", Button).disabled = False
         self._set_status(f"[green]✓ Análisis completado ({report.execution_time_ms:.2f}ms)[/green]")
+        self._start_ai_analysis(report)
+
+    def _start_ai_analysis(self, report: QueryAnalysisReport) -> None:
+        """Start AI analysis after factual results are already visible."""
+        try:
+            from query_analyzer.core.ai_analyzer import AIAnalyzer
+
+            if not AIAnalyzer().available:
+                self.query_one(AIInsightsPanel).render_ai_analysis(None, None)
+                return
+        except Exception:
+            self.query_one(AIInsightsPanel).render_ai_analysis(None, None)
+            return
+
+        self.query_one(AIInsightsPanel).set_loading_state()
+        try:
+            self.run_ai_analysis_worker(report)
+        except Exception:
+            self.query_one(AIInsightsPanel).render_ai_analysis(None, None)
+
+    @work(thread=True)
+    def run_ai_analysis_worker(self, report: QueryAnalysisReport) -> None:
+        """Run optional AI analysis without blocking factual EXPLAIN results."""
+        try:
+            from query_analyzer.core.ai_analyzer import AIAnalyzer
+
+            ai_result = AIAnalyzer().analyze(
+                plan_json=report.raw_plan or report.plan_summary or "No plan available",
+                query=report.query,
+                engine=report.engine,
+            )
+
+            if ai_result is None:
+                self.app.call_from_thread(self._on_ai_analysis_complete, report, None, None)
+                return
+
+            model_result = AIAnalysisResult(
+                summary=ai_result.summary,
+                observations=ai_result.observations,
+                recommendations=ai_result.recommendations,
+                suggested_query=ai_result.suggested_query,
+                raw_response=ai_result.raw_response,
+            )
+            self.app.call_from_thread(self._on_ai_analysis_complete, report, model_result, None)
+        except Exception as error:
+            self.app.call_from_thread(self._on_ai_analysis_complete, report, None, str(error))
+
+    def _on_ai_analysis_complete(
+        self,
+        report: QueryAnalysisReport,
+        ai_analysis: AIAnalysisResult | None,
+        ai_error: str | None,
+    ) -> None:
+        """Render AI results only if they belong to the active report."""
+        if self._current_report is not report:
+            return
+
+        report.ai_analysis = ai_analysis
+        self._current_ai_error = ai_error
+        self.query_one(AIInsightsPanel).render_ai_analysis(ai_analysis, ai_error)
 
     def _on_analysis_error(self, error_message: str) -> None:
         """Handle analysis error.

--- a/tests/unit/test_api_app.py
+++ b/tests/unit/test_api_app.py
@@ -1,0 +1,28 @@
+"""Tests for the FastAPI app entrypoint."""
+
+import importlib
+from unittest.mock import patch
+
+api_app = importlib.import_module("query_analyzer.api.app")
+
+
+def test_main_uses_default_api_host_and_port(monkeypatch) -> None:
+    """API entrypoint defaults to the integrations port."""
+    monkeypatch.delenv("QA_API_HOST", raising=False)
+    monkeypatch.delenv("QA_API_PORT", raising=False)
+
+    with patch("query_analyzer.api.app.uvicorn.run") as run:
+        api_app.main()
+
+    run.assert_called_once_with("query_analyzer.api.app:app", host="127.0.0.1", port=8000)
+
+
+def test_main_uses_api_host_and_port_from_environment(monkeypatch) -> None:
+    """API entrypoint allows local integration overrides."""
+    monkeypatch.setenv("QA_API_HOST", "0.0.0.0")
+    monkeypatch.setenv("QA_API_PORT", "8001")
+
+    with patch("query_analyzer.api.app.uvicorn.run") as run:
+        api_app.main()
+
+    run.assert_called_once_with("query_analyzer.api.app:app", host="0.0.0.0", port=8001)

--- a/tests/unit/test_api_router.py
+++ b/tests/unit/test_api_router.py
@@ -1,0 +1,158 @@
+"""Tests for Query Analyzer API routes."""
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from query_analyzer.adapters.models import QueryAnalysisReport
+from query_analyzer.api.app import app
+
+
+@dataclass
+class StubAIResult:
+    """Small AI result shape matching the core analyzer contract."""
+
+    summary: str
+    observations: list[str]
+    recommendations: list[str]
+    suggested_query: str | None = None
+    raw_response: str | None = None
+
+
+def test_explain_includes_optional_ai_analysis() -> None:
+    """EXPLAIN includes AI analysis when explicitly requested."""
+    adapter = MagicMock()
+    adapter.__enter__.return_value = adapter
+    adapter.execute_explain.return_value = QueryAnalysisReport(
+        engine="sqlite",
+        query="SELECT 1",
+        execution_time_ms=1.0,
+        plan_summary="SCAN CONSTANT ROW",
+        raw_plan={"Plan": {"Node Type": "Result"}},
+        metrics={"node_count": 1},
+    )
+    analyzer = MagicMock()
+    analyzer.available = True
+    analyzer.analyze.return_value = StubAIResult(
+        summary="La consulta es simple y eficiente.",
+        observations=["No requiere lectura de tablas."],
+        recommendations=["No se requieren cambios."],
+    )
+
+    with (
+        patch("query_analyzer.api.router.AdapterRegistry.create", return_value=adapter),
+        patch("query_analyzer.api.router.AIAnalyzer", return_value=analyzer),
+    ):
+        response = TestClient(app).post(
+            "/api/v1/analyzer/explain",
+            json={
+                "connection": {"engine": "sqlite", "database": ":memory:"},
+                "query": "SELECT 1",
+                "include_ai": True,
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["ai_analysis"] == {
+        "summary": "La consulta es simple y eficiente.",
+        "observations": ["No requiere lectura de tablas."],
+        "recommendations": ["No se requieren cambios."],
+        "suggested_query": None,
+        "raw_response": None,
+    }
+    analyzer.analyze.assert_called_once_with(
+        plan_json={"Plan": {"Node Type": "Result"}},
+        query="SELECT 1",
+        engine="sqlite",
+    )
+
+
+def test_explain_still_succeeds_when_optional_ai_fails() -> None:
+    """AI errors should not turn a successful EXPLAIN into a failed response."""
+    adapter = MagicMock()
+    adapter.__enter__.return_value = adapter
+    adapter.execute_explain.return_value = QueryAnalysisReport(
+        engine="sqlite",
+        query="SELECT 1",
+        execution_time_ms=1.0,
+        plan_summary="SCAN CONSTANT ROW",
+    )
+    analyzer = MagicMock()
+    analyzer.available = True
+    analyzer.analyze.side_effect = RuntimeError("AI provider unavailable")
+
+    with (
+        patch("query_analyzer.api.router.AdapterRegistry.create", return_value=adapter),
+        patch("query_analyzer.api.router.AIAnalyzer", return_value=analyzer),
+    ):
+        response = TestClient(app).post(
+            "/api/v1/analyzer/explain",
+            json={
+                "connection": {"engine": "sqlite", "database": ":memory:"},
+                "query": "SELECT 1",
+                "include_ai": True,
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["ai_analysis"] is None
+
+
+def test_explain_does_not_call_ai_by_default() -> None:
+    """EXPLAIN returns factual data immediately unless include_ai is requested."""
+    adapter = MagicMock()
+    adapter.__enter__.return_value = adapter
+    adapter.execute_explain.return_value = QueryAnalysisReport(
+        engine="sqlite",
+        query="SELECT 1",
+        execution_time_ms=1.0,
+        plan_summary="SCAN CONSTANT ROW",
+    )
+
+    with (
+        patch("query_analyzer.api.router.AdapterRegistry.create", return_value=adapter),
+        patch("query_analyzer.api.router.AIAnalyzer") as analyzer,
+    ):
+        response = TestClient(app).post(
+            "/api/v1/analyzer/explain",
+            json={
+                "connection": {"engine": "sqlite", "database": ":memory:"},
+                "query": "SELECT 1",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["ai_analysis"] is None
+    analyzer.assert_not_called()
+
+
+def test_ai_endpoint_uses_environment_configuration_when_ai_config_is_omitted() -> None:
+    """The async AI endpoint can use QA_AI_* from the API process environment."""
+    analyzer = MagicMock()
+    analyzer.available = True
+    analyzer.analyze.return_value = StubAIResult(
+        summary="Plan eficiente.",
+        observations=[],
+        recommendations=[],
+    )
+
+    with patch("query_analyzer.api.router.AIAnalyzer", return_value=analyzer) as analyzer_cls:
+        response = TestClient(app).post(
+            "/api/v1/analyzer/ai",
+            json={
+                "plan_json": {"Plan": {"Node Type": "Result"}},
+                "query": "SELECT 1",
+                "engine": "sqlite",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["summary"] == "Plan eficiente."
+    analyzer_cls.assert_called_once_with()

--- a/tests/unit/test_connection_diagnostics.py
+++ b/tests/unit/test_connection_diagnostics.py
@@ -301,9 +301,7 @@ def test_socket_timeout_is_classified_as_timeout() -> None:
 def test_adapter_disconnects_when_connect_raises(mock_registry: MagicMock) -> None:
     """Verifica que se llame a disconnect cuando connect lanza una excepción."""
     config = ConnectionConfig(
-        engine="postgresql",
-        host="localhost",
-        port=5432,
+        engine="sqlite",
         database="mydb",
     )
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,97 @@
+"""Tests for the Query Analyzer MCP server."""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from query_analyzer.adapters.models import ConnectionConfig, QueryAnalysisReport
+from query_analyzer.mcp_server import analyze_query_with_profile
+
+
+def test_analyze_query_uses_explicit_profile() -> None:
+    """The MCP tool resolves an explicit profile and returns report data."""
+    connection_config = ConnectionConfig(engine="sqlite", database=":memory:")
+    config_manager = MagicMock()
+    config_manager.get_connection_config.return_value = connection_config
+    adapter = MagicMock()
+    adapter.__enter__.return_value = adapter
+    adapter.execute_explain.return_value = QueryAnalysisReport(
+        engine="sqlite",
+        query="SELECT 1",
+        execution_time_ms=1.5,
+        plan_summary="SCAN CONSTANT ROW",
+        raw_plan={"detail": "constant"},
+        metrics={"node_count": 1},
+        analyzed_at=datetime(2026, 6, 15, tzinfo=UTC),
+    )
+
+    with (
+        patch("query_analyzer.mcp_server.ConfigManager", return_value=config_manager),
+        patch("query_analyzer.mcp_server.AdapterRegistry.create", return_value=adapter) as create,
+    ):
+        result = analyze_query_with_profile("SELECT 1", profile="local")
+
+    assert result == {
+        "success": True,
+        "profile": "local",
+        "engine": "sqlite",
+        "query": "SELECT 1",
+        "execution_time_ms": 1.5,
+        "plan_summary": "SCAN CONSTANT ROW",
+        "metrics": {"node_count": 1},
+        "raw_plan": {"detail": "constant"},
+        "analyzed_at": "2026-06-15T00:00:00Z",
+        "error": None,
+    }
+    config_manager.get_connection_config.assert_called_once_with("local")
+    create.assert_called_once_with("sqlite", connection_config)
+    adapter.execute_explain.assert_called_once_with("SELECT 1")
+
+
+def test_analyze_query_uses_default_profile_when_omitted() -> None:
+    """The MCP tool falls back to Query Analyzer's default profile."""
+    connection_config = ConnectionConfig(engine="sqlite", database=":memory:")
+    app_config = MagicMock(default_profile="default-sqlite")
+    config_manager = MagicMock()
+    config_manager.load_config.return_value = app_config
+    config_manager.get_connection_config.return_value = connection_config
+    adapter = MagicMock()
+    adapter.__enter__.return_value = adapter
+    adapter.execute_explain.return_value = QueryAnalysisReport(
+        engine="sqlite",
+        query="SELECT 1",
+        execution_time_ms=1.0,
+    )
+
+    with (
+        patch("query_analyzer.mcp_server.ConfigManager", return_value=config_manager),
+        patch("query_analyzer.mcp_server.AdapterRegistry.create", return_value=adapter),
+    ):
+        result = analyze_query_with_profile("SELECT 1")
+
+    assert result["success"] is True
+    assert result["profile"] == "default-sqlite"
+    config_manager.get_connection_config.assert_called_once_with("default-sqlite")
+
+
+def test_analyze_query_returns_error_without_profile() -> None:
+    """The MCP tool reports a useful error when no profile can be resolved."""
+    config_manager = MagicMock()
+    config_manager.load_config.return_value = MagicMock(default_profile=None)
+
+    with patch("query_analyzer.mcp_server.ConfigManager", return_value=config_manager):
+        result = analyze_query_with_profile("SELECT 1")
+
+    assert result["success"] is False
+    assert "No profile provided" in result["error"]
+
+
+def test_analyze_query_rejects_empty_query() -> None:
+    """The MCP tool rejects blank input before touching configuration."""
+    result = analyze_query_with_profile("   ")
+
+    assert result == {
+        "success": False,
+        "engine": "",
+        "query": "   ",
+        "error": "Query cannot be empty.",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.42.89"
 source = { registry = "https://pypi.org/simple" }
@@ -409,6 +418,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.18"
 source = { registry = "https://pypi.org/simple" }
@@ -469,6 +487,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -562,6 +607,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
 ]
 
 [[package]]
@@ -816,12 +886,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -968,6 +1066,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.1.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -1022,6 +1129,7 @@ dependencies = [
     { name = "elasticsearch" },
     { name = "fastapi" },
     { name = "influxdb-client" },
+    { name = "mcp" },
     { name = "neo4j" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
@@ -1030,6 +1138,7 @@ dependencies = [
     { name = "pymysql" },
     { name = "pyyaml" },
     { name = "redis" },
+    { name = "requests" },
     { name = "rich" },
     { name = "textual" },
     { name = "typer" },
@@ -1061,6 +1170,7 @@ requires-dist = [
     { name = "elasticsearch", specifier = ">=8.0.0,<9.0.0" },
     { name = "fastapi", specifier = ">=0.111.0" },
     { name = "influxdb-client", specifier = ">=1.36.0" },
+    { name = "mcp", specifier = ">=1.27,<2" },
     { name = "neo4j", specifier = ">=5.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pydantic", specifier = ">=2.12.5" },
@@ -1069,6 +1179,7 @@ requires-dist = [
     { name = "pymysql", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "redis", specifier = ">=5.0" },
+    { name = "requests", specifier = ">=2.32.0" },
     { name = "rich", specifier = ">=14.3.3" },
     { name = "textual", specifier = ">=8.2.2" },
     { name = "typer", specifier = ">=0.24.1" },
@@ -1115,6 +1226,19 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1154,6 +1278,72 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
 ]
 
 [[package]]
@@ -1209,6 +1399,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add a stdio MCP server exposing `analyze_query` through local Query Analyzer profiles.
- Make the FastAPI entrypoint configurable with `QA_API_HOST` and `QA_API_PORT`, defaulting integrations to port 8000.
- Split factual EXPLAIN from optional AI analysis so `/explain` returns quickly and `/ai` can use server-side `QA_AI_*` variables.
- Update the TUI so AI analysis runs asynchronously after the factual report is visible.

## Impact
- Programming agents can call Query Analyzer through MCP without requiring the REST API to be running.
- API and TUI users get faster factual results; AI analysis no longer blocks the whole workflow.
- `include_ai=true` remains available for callers that explicitly want synchronous AI analysis.

## Validation
- `.venv\Scripts\ruff.exe check query_analyzer tests/unit`
- `.venv\Scripts\ruff.exe format --check query_analyzer tests/unit`
- `.venv\Scripts\python.exe -m mypy query_analyzer`
- `.venv\Scripts\python.exe -m pytest tests/unit/ -q` (`481 passed, 1 skipped`)
