### PR TITLE
feat: add vscode query analyzer extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ MANIFEST
 # UV - Modern Python Package Manager
 # ==========================================
 .venv/
+node_modules/
+integrations/vscode-query-analyzer/out/
 .env
 .env.local
 .env.*.local
@@ -37,6 +39,8 @@ MANIFEST
 # IDE & Editors
 # ==========================================
 .vscode/
+!integrations/vscode-query-analyzer/.vscode/
+!integrations/vscode-query-analyzer/.vscode/launch.json
 .idea/
 *.swp
 *.swo

--- a/integrations/vscode-query-analyzer/.vscode/launch.json
+++ b/integrations/vscode-query-analyzer/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Query Analyzer Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "npm: compile"
+    }
+  ]
+}

--- a/integrations/vscode-query-analyzer/.vscodeignore
+++ b/integrations/vscode-query-analyzer/.vscodeignore
@@ -1,0 +1,5 @@
+node_modules
+src
+test
+tsconfig.json
+*.map

--- a/integrations/vscode-query-analyzer/package-lock.json
+++ b/integrations/vscode-query-analyzer/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "vscode-query-analyzer",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vscode-query-analyzer",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "@types/vscode": "^1.90.0",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "vscode": "^1.90.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/integrations/vscode-query-analyzer/package.json
+++ b/integrations/vscode-query-analyzer/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "vscode-query-analyzer",
+  "displayName": "Query Analyzer",
+  "description": "Analyze selected SQL with the local Query Analyzer API.",
+  "version": "0.1.0",
+  "publisher": "query-analyzer",
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:query-analyzer.analyze"
+  ],
+  "main": "./out/src/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "query-analyzer.analyze",
+        "title": "Analizar Rendimiento",
+        "category": "Query Analyzer"
+      }
+    ],
+    "configuration": {
+      "title": "Query Analyzer",
+      "properties": {
+        "queryAnalyzer.apiUrl": {
+          "type": "string",
+          "default": "http://localhost:8000",
+          "description": "Base URL for the local Query Analyzer API."
+        },
+        "queryAnalyzer.connection": {
+          "type": "object",
+          "default": {
+            "engine": "sqlite",
+            "database": ":memory:"
+          },
+          "description": "Legacy fallback connection payload. Prefer queryAnalyzer.profiles for new setups."
+        },
+        "queryAnalyzer.profiles": {
+          "type": "object",
+          "default": {},
+          "description": "Named connection profiles sent to /api/v1/analyzer/explain. Passwords created through the extension are stored in VS Code SecretStorage."
+        },
+        "queryAnalyzer.defaultProfile": {
+          "type": "string",
+          "default": "",
+          "description": "Default Query Analyzer profile name."
+        }
+      }
+    },
+    "menus": {
+      "editor/context": [
+        {
+          "command": "query-analyzer.analyze",
+          "when": "editorHasSelection",
+          "group": "navigation@20"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "test": "npm run compile && node --test out/test/*.test.js"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/vscode": "^1.90.0",
+    "typescript": "^5.7.2"
+  }
+}

--- a/integrations/vscode-query-analyzer/src/apiClient.ts
+++ b/integrations/vscode-query-analyzer/src/apiClient.ts
@@ -1,0 +1,305 @@
+export type ConnectionPayload = Record<string, unknown>;
+
+export interface AnalyzePayload {
+  connection: ConnectionPayload;
+  query: string;
+}
+
+export interface AIAnalyzePayload {
+  plan_json: unknown;
+  query: string;
+  engine: string;
+}
+
+export interface AnalyzeResponse {
+  success: boolean;
+  engine?: string;
+  query?: string;
+  execution_time_ms?: number | null;
+  plan_summary?: string | null;
+  ai_analysis?: AIAnalysis | null;
+  metrics?: Record<string, unknown>;
+  raw_plan?: unknown;
+  error?: string | null;
+}
+
+export interface AIAnalyzeResponse extends AIAnalysis {
+  success: boolean;
+  error?: string | null;
+}
+
+export interface AIAnalysis {
+  summary: string;
+  observations?: string[];
+  recommendations?: string[];
+  suggested_query?: string | null;
+  raw_response?: string | null;
+}
+
+export function buildAnalyzeUrl(baseUrl: string): string {
+  const normalized = baseUrl.trim().replace(/\/+$/, "");
+  return `${normalized}/api/v1/analyzer/explain`;
+}
+
+export function buildAiAnalyzeUrl(baseUrl: string): string {
+  const normalized = baseUrl.trim().replace(/\/+$/, "");
+  return `${normalized}/api/v1/analyzer/ai`;
+}
+
+export function buildAnalyzePayload(query: string, connection: ConnectionPayload): AnalyzePayload {
+  return {
+    connection,
+    query
+  };
+}
+
+export async function postAnalyze(
+  baseUrl: string,
+  payload: AnalyzePayload,
+  fetchImpl: typeof fetch = fetch
+): Promise<AnalyzeResponse> {
+  const response = await fetchImpl(buildAnalyzeUrl(baseUrl), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+
+  const body = (await response.json()) as AnalyzeResponse;
+  if (!response.ok) {
+    return {
+      success: false,
+      error: body.error ?? `HTTP ${response.status}`
+    };
+  }
+
+  return body;
+}
+
+export async function postAiAnalyze(
+  baseUrl: string,
+  payload: AIAnalyzePayload,
+  fetchImpl: typeof fetch = fetch
+): Promise<AIAnalyzeResponse> {
+  const response = await fetchImpl(buildAiAnalyzeUrl(baseUrl), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+
+  const body = (await response.json()) as AIAnalyzeResponse;
+  if (!response.ok) {
+    return {
+      success: false,
+      summary: "",
+      error: body.error ?? `HTTP ${response.status}`
+    };
+  }
+
+  return body;
+}
+
+export function renderAnalysisHtml(result: AnalyzeResponse): string {
+  const statusClass = result.success ? "success" : "error";
+  const statusText = result.success ? "Analisis completado" : "Analisis fallido";
+  const summary = result.plan_summary ?? "No plan summary returned.";
+  const error = result.error ? `<section><h2>Error</h2><pre>${escapeHtml(result.error)}</pre></section>` : "";
+  const rawDetails = JSON.stringify(
+    {
+      metrics: result.metrics ?? {},
+      raw_plan: result.raw_plan ?? {}
+    },
+    null,
+    2
+  );
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body { color: var(--vscode-foreground); font-family: var(--vscode-font-family); padding: 20px; }
+    h1, h2, h3 { font-weight: 600; }
+    h1 { margin-top: 0; }
+    section { margin: 22px 0; }
+    .status { border-left: 4px solid; padding: 8px 12px; margin-bottom: 16px; }
+    .success { border-color: var(--vscode-testing-iconPassed); }
+    .error { border-color: var(--vscode-testing-iconFailed); }
+    .muted { color: var(--vscode-descriptionForeground); }
+    .metric-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 8px; }
+    .metric { background: var(--vscode-textCodeBlock-background); border: 1px solid var(--vscode-panel-border); padding: 10px; }
+    .metric-label { color: var(--vscode-descriptionForeground); font-size: 12px; }
+    .metric-value { font-size: 18px; margin-top: 4px; }
+    ul { padding-left: 20px; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { border-bottom: 1px solid var(--vscode-panel-border); padding: 6px; text-align: left; }
+    th { color: var(--vscode-descriptionForeground); font-weight: 600; }
+    pre { background: var(--vscode-textCodeBlock-background); overflow: auto; padding: 12px; white-space: pre-wrap; }
+    code { font-family: var(--vscode-editor-font-family); }
+    details { background: var(--vscode-textCodeBlock-background); padding: 10px 12px; }
+    summary { cursor: pointer; font-weight: 600; }
+  </style>
+  <title>Query Analyzer</title>
+</head>
+<body>
+  <h1>Query Analyzer</h1>
+  <div class="status ${statusClass}">
+    <strong>${statusText}</strong>
+    <div>${escapeHtml(result.engine ?? "unknown engine")}</div>
+    <div>${formatExecutionTime(result.execution_time_ms)}</div>
+  </div>
+  ${error}
+  ${renderAiAnalysis(result)}
+  <section>
+    <h2>Plan Summary</h2>
+    <pre>${escapeHtml(summary)}</pre>
+  </section>
+  ${renderMetrics(result.metrics ?? {})}
+  ${renderScanNodes(result.metrics ?? {})}
+  <section>
+    <details>
+      <summary>Ver datos tecnicos completos</summary>
+      <pre><code>${escapeHtml(rawDetails)}</code></pre>
+    </details>
+  </section>
+</body>
+</html>`;
+}
+
+function formatExecutionTime(value: number | null | undefined): string {
+  return typeof value === "number" ? `${value.toFixed(2)} ms` : "No execution time returned";
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function renderAiAnalysis(result: AnalyzeResponse): string {
+  if (result.success && result.ai_analysis === undefined) {
+    return `<section>
+      <h2>Analisis con IA</h2>
+      <p class="muted">Generando analisis con IA en segundo plano...</p>
+    </section>`;
+  }
+
+  if (result.ai_analysis === null) {
+    return `<section>
+      <h2>Analisis con IA</h2>
+      <p class="muted">No hay analisis de IA disponible para este resultado.</p>
+    </section>`;
+  }
+
+  if (!result.ai_analysis) {
+    return "";
+  }
+
+  const observations = renderList(result.ai_analysis.observations ?? []);
+  const recommendations = renderList(result.ai_analysis.recommendations ?? []);
+  const suggestedQuery = result.ai_analysis.suggested_query
+    ? `<h3>Consulta sugerida</h3><pre><code>${escapeHtml(result.ai_analysis.suggested_query)}</code></pre>`
+    : "";
+
+  return `<section>
+    <h2>Analisis con IA</h2>
+    <p>${escapeHtml(result.ai_analysis.summary)}</p>
+    ${observations ? `<h3>Observaciones</h3>${observations}` : ""}
+    ${recommendations ? `<h3>Recomendaciones</h3>${recommendations}` : ""}
+    ${suggestedQuery}
+  </section>`;
+}
+
+function renderList(items: string[]): string {
+  if (!items.length) {
+    return "";
+  }
+
+  return `<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`;
+}
+
+function renderMetrics(metrics: Record<string, unknown>): string {
+  const scalarMetrics = Object.entries(metrics).filter(([, value]) => isScalar(value));
+
+  if (!scalarMetrics.length) {
+    return `<section><h2>Metricas</h2><p class="muted">No se devolvieron metricas.</p></section>`;
+  }
+
+  return `<section>
+    <h2>Metricas clave</h2>
+    <div class="metric-grid">
+      ${scalarMetrics
+        .map(
+          ([key, value]) => `<div class="metric">
+            <div class="metric-label">${escapeHtml(formatMetricLabel(key))}</div>
+            <div class="metric-value">${escapeHtml(formatMetricValue(value))}</div>
+          </div>`
+        )
+        .join("")}
+    </div>
+  </section>`;
+}
+
+function renderScanNodes(metrics: Record<string, unknown>): string {
+  const scanNodes = Array.isArray(metrics.scan_nodes) ? metrics.scan_nodes : [];
+  const rows = scanNodes.filter((node): node is Record<string, unknown> => isRecord(node));
+
+  if (!rows.length) {
+    return "";
+  }
+
+  return `<section>
+    <h2>Nodos de lectura</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Tipo</th>
+          <th>Relacion</th>
+          <th>Filas</th>
+          <th>Tiempo</th>
+          <th>Costo</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${rows
+          .map(
+            (node) => `<tr>
+              <td>${escapeHtml(String(node["Node Type"] ?? node.type ?? "-"))}</td>
+              <td>${escapeHtml(String(node["Relation Name"] ?? node.relation ?? "-"))}</td>
+              <td>${escapeHtml(String(node["Actual Rows"] ?? node.actual_rows ?? "-"))}</td>
+              <td>${escapeHtml(String(node["Actual Total Time"] ?? node.actual_time ?? "-"))}</td>
+              <td>${escapeHtml(String(node["Total Cost"] ?? node.cost ?? "-"))}</td>
+            </tr>`
+          )
+          .join("")}
+      </tbody>
+    </table>
+  </section>`;
+}
+
+function isScalar(value: unknown): boolean {
+  return ["string", "number", "boolean"].includes(typeof value) || value === null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatMetricLabel(key: string): string {
+  return key.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function formatMetricValue(value: unknown): string {
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? String(value) : value.toFixed(3);
+  }
+
+  return String(value);
+}

--- a/integrations/vscode-query-analyzer/src/extension.ts
+++ b/integrations/vscode-query-analyzer/src/extension.ts
@@ -1,0 +1,294 @@
+import * as vscode from "vscode";
+
+import {
+  ConnectionPayload,
+  buildAnalyzePayload,
+  postAnalyze,
+  postAiAnalyze,
+  renderAnalysisHtml
+} from "./apiClient";
+import {
+  ProfilesConfig,
+  SUPPORTED_ENGINES,
+  QueryAnalyzerProfile,
+  buildProfileDescription,
+  defaultPortForEngine,
+  profilesFromConfig,
+  upsertProfile
+} from "./profiles";
+
+const PASSWORD_PREFIX = "queryAnalyzer.profilePassword.";
+
+export function activate(context: vscode.ExtensionContext): void {
+  const disposable = vscode.commands.registerCommand("query-analyzer.analyze", async () => {
+    const editor = vscode.window.activeTextEditor;
+    const selectedText = editor?.document.getText(editor.selection).trim();
+
+    if (!selectedText) {
+      vscode.window.showWarningMessage("Select a SQL query before running Query Analyzer.");
+      return;
+    }
+
+    const config = vscode.workspace.getConfiguration("queryAnalyzer");
+    const apiUrl = config.get<string>("apiUrl", "http://localhost:8000");
+    const profile = await selectProfile(config, context);
+
+    if (!profile) {
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      "queryAnalyzerResults",
+      "Query Analyzer",
+      vscode.ViewColumn.Beside,
+      { enableScripts: false }
+    );
+
+    panel.webview.html = renderAnalysisHtml({
+      success: true,
+      plan_summary: "Analyzing selected query..."
+    });
+
+    try {
+      const result = await postAnalyze(
+        apiUrl,
+        buildAnalyzePayload(selectedText, profile.connection)
+      );
+      panel.webview.html = renderAnalysisHtml(result);
+
+      if (result.success && (result.raw_plan || result.plan_summary) && result.engine) {
+        void renderAiAnalysisWhenReady(panel, apiUrl, result);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      panel.webview.html = renderAnalysisHtml({
+        success: false,
+        error: `Could not reach Query Analyzer API at ${apiUrl}: ${message}`
+      });
+    }
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+export function deactivate(): void {}
+
+async function renderAiAnalysisWhenReady(
+  panel: vscode.WebviewPanel,
+  apiUrl: string,
+  result: Awaited<ReturnType<typeof postAnalyze>>
+): Promise<void> {
+  try {
+    const aiResult = await postAiAnalyze(apiUrl, {
+      plan_json: result.raw_plan ?? result.plan_summary ?? "No plan available",
+      query: result.query ?? "",
+      engine: result.engine ?? ""
+    });
+
+    panel.webview.html = renderAnalysisHtml({
+      ...result,
+      ai_analysis: aiResult.success
+        ? {
+            summary: aiResult.summary,
+            observations: aiResult.observations ?? [],
+            recommendations: aiResult.recommendations ?? [],
+            suggested_query: aiResult.suggested_query ?? null,
+            raw_response: aiResult.raw_response ?? null
+          }
+        : null
+    });
+  } catch {
+    panel.webview.html = renderAnalysisHtml({
+      ...result,
+      ai_analysis: null
+    });
+  }
+}
+
+async function selectProfile(
+  config: vscode.WorkspaceConfiguration,
+  context: vscode.ExtensionContext
+): Promise<QueryAnalyzerProfile | undefined> {
+  const configuredProfiles = config.get<ProfilesConfig>("profiles", {});
+  const profiles = await withStoredPasswords(profilesFromConfig(configuredProfiles), context);
+
+  if (profiles.length === 0) {
+    const create = "Create Query Analyzer profile";
+    const selected = await vscode.window.showInformationMessage(
+      "No Query Analyzer profiles configured.",
+      create
+    );
+    return selected === create ? createProfile(config, context, configuredProfiles) : undefined;
+  }
+
+  const defaultProfile = config.get<string>("defaultProfile", "");
+  const createLabel = "$(add) Create new profile";
+  const items = [
+    ...profiles.map((profile) => ({
+      label: profile.name === defaultProfile ? `$(star-full) ${profile.name}` : profile.name,
+      description: buildProfileDescription(profile),
+      profile
+    })),
+    {
+      label: createLabel,
+      description: "Add a database connection profile",
+      profile: undefined
+    }
+  ];
+
+  const selected = await vscode.window.showQuickPick(items, {
+    placeHolder: "Choose the Query Analyzer profile for this analysis"
+  });
+
+  if (!selected) {
+    return undefined;
+  }
+
+  if (!selected.profile) {
+    return createProfile(config, context, configuredProfiles);
+  }
+
+  return selected.profile;
+}
+
+async function withStoredPasswords(
+  profiles: QueryAnalyzerProfile[],
+  context: vscode.ExtensionContext
+): Promise<QueryAnalyzerProfile[]> {
+  const resolved: QueryAnalyzerProfile[] = [];
+
+  for (const profile of profiles) {
+    const password = await context.secrets.get(`${PASSWORD_PREFIX}${profile.name}`);
+    resolved.push({
+      ...profile,
+      connection: password ? { ...profile.connection, password } : profile.connection
+    });
+  }
+
+  return resolved;
+}
+
+async function createProfile(
+  config: vscode.WorkspaceConfiguration,
+  context: vscode.ExtensionContext,
+  configuredProfiles: ProfilesConfig
+): Promise<QueryAnalyzerProfile | undefined> {
+  const name = await vscode.window.showInputBox({
+    title: "Query Analyzer Profile",
+    prompt: "Profile name",
+    validateInput: (value) => {
+      if (!value.trim()) {
+        return "Profile name is required.";
+      }
+      if (configuredProfiles[value.trim()]) {
+        return "A profile with this name already exists.";
+      }
+      return undefined;
+    }
+  });
+
+  if (!name) {
+    return undefined;
+  }
+
+  const engine = await vscode.window.showQuickPick([...SUPPORTED_ENGINES], {
+    title: "Query Analyzer Profile",
+    placeHolder: "Database engine"
+  });
+
+  if (!engine) {
+    return undefined;
+  }
+
+  const database = await vscode.window.showInputBox({
+    title: "Query Analyzer Profile",
+    prompt: engine === "sqlite" ? "SQLite database path or :memory:" : "Database name",
+    value: engine === "sqlite" ? ":memory:" : ""
+  });
+
+  if (database === undefined) {
+    return undefined;
+  }
+
+  const connection: ConnectionPayload = {
+    engine,
+    database
+  };
+
+  if (engine !== "sqlite") {
+    const host = await vscode.window.showInputBox({
+      title: "Query Analyzer Profile",
+      prompt: "Host",
+      value: "localhost"
+    });
+
+    if (host === undefined) {
+      return undefined;
+    }
+
+    const defaultPort = defaultPortForEngine(engine);
+    const port = await vscode.window.showInputBox({
+      title: "Query Analyzer Profile",
+      prompt: "Port",
+      value: defaultPort ? String(defaultPort) : "",
+      validateInput: (value) => {
+        if (!value.trim()) {
+          return undefined;
+        }
+        const parsed = Number(value);
+        return Number.isInteger(parsed) && parsed > 0 && parsed <= 65535
+          ? undefined
+          : "Port must be a number between 1 and 65535.";
+      }
+    });
+
+    if (port === undefined) {
+      return undefined;
+    }
+
+    const username = await vscode.window.showInputBox({
+      title: "Query Analyzer Profile",
+      prompt: "Username (optional)"
+    });
+
+    if (username === undefined) {
+      return undefined;
+    }
+
+    const password = await vscode.window.showInputBox({
+      title: "Query Analyzer Profile",
+      prompt: "Password (optional, stored in VS Code SecretStorage)",
+      password: true
+    });
+
+    if (password === undefined) {
+      return undefined;
+    }
+
+    connection.host = host;
+    if (port.trim()) {
+      connection.port = Number(port);
+    }
+    if (username.trim()) {
+      connection.username = username;
+    }
+    if (password) {
+      await context.secrets.store(`${PASSWORD_PREFIX}${name.trim()}`, password);
+      connection.password = password;
+    }
+  }
+
+  const profile = {
+    name: name.trim(),
+    connection
+  };
+  const target = vscode.workspace.workspaceFolders
+    ? vscode.ConfigurationTarget.Workspace
+    : vscode.ConfigurationTarget.Global;
+
+  await config.update("profiles", upsertProfile(configuredProfiles, profile), target);
+  await config.update("defaultProfile", profile.name, target);
+
+  vscode.window.showInformationMessage(`Query Analyzer profile '${profile.name}' created.`);
+  return profile;
+}

--- a/integrations/vscode-query-analyzer/src/profiles.ts
+++ b/integrations/vscode-query-analyzer/src/profiles.ts
@@ -1,0 +1,59 @@
+import { ConnectionPayload } from "./apiClient";
+
+export interface QueryAnalyzerProfile {
+  name: string;
+  connection: ConnectionPayload;
+}
+
+export type ProfilesConfig = Record<string, ConnectionPayload>;
+
+export const SUPPORTED_ENGINES = [
+  "postgresql",
+  "mysql",
+  "sqlite",
+  "mongodb",
+  "redis",
+  "cockroachdb",
+  "yugabytedb",
+  "neo4j",
+  "influxdb",
+  "elasticsearch",
+  "mssql"
+] as const;
+
+export function profilesFromConfig(profiles: ProfilesConfig | undefined): QueryAnalyzerProfile[] {
+  return Object.entries(profiles ?? {})
+    .filter(([name]) => name.trim().length > 0)
+    .map(([name, connection]) => ({ name, connection }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function upsertProfile(
+  profiles: ProfilesConfig | undefined,
+  profile: QueryAnalyzerProfile
+): ProfilesConfig {
+  return {
+    ...(profiles ?? {}),
+    [profile.name]: profile.connection
+  };
+}
+
+export function defaultPortForEngine(engine: string): number | undefined {
+  const ports: Record<string, number> = {
+    postgresql: 5432,
+    mysql: 3306,
+    mongodb: 27017,
+    redis: 6379,
+    neo4j: 7687,
+    elasticsearch: 9200,
+    mssql: 1433
+  };
+
+  return ports[engine];
+}
+
+export function buildProfileDescription(profile: QueryAnalyzerProfile): string {
+  const { engine, host, port, database } = profile.connection;
+  const endpoint = host ? `${host}${port ? `:${port}` : ""}` : "";
+  return [engine, endpoint, database].filter(Boolean).join(" - ");
+}

--- a/integrations/vscode-query-analyzer/test/apiClient.test.ts
+++ b/integrations/vscode-query-analyzer/test/apiClient.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildAiAnalyzeUrl,
+  buildAnalyzePayload,
+  buildAnalyzeUrl,
+  renderAnalysisHtml
+} from "../src/apiClient";
+import {
+  buildProfileDescription,
+  defaultPortForEngine,
+  profilesFromConfig,
+  upsertProfile
+} from "../src/profiles";
+
+test("buildAnalyzeUrl appends the analyzer explain endpoint", () => {
+  assert.equal(
+    buildAnalyzeUrl("http://localhost:8000/"),
+    "http://localhost:8000/api/v1/analyzer/explain"
+  );
+});
+
+test("buildAiAnalyzeUrl appends the analyzer ai endpoint", () => {
+  assert.equal(buildAiAnalyzeUrl("http://localhost:8000/"), "http://localhost:8000/api/v1/analyzer/ai");
+});
+
+test("buildAnalyzePayload preserves the selected query and connection", () => {
+  const connection = { engine: "postgresql", database: "query_analyzer" };
+
+  assert.deepEqual(buildAnalyzePayload("SELECT 1", connection), {
+    connection,
+    query: "SELECT 1"
+  });
+});
+
+test("renderAnalysisHtml escapes API content", () => {
+  const html = renderAnalysisHtml({
+    success: false,
+    engine: "sqlite",
+    error: "<script>alert(1)</script>"
+  });
+
+  assert.match(html, /Analisis fallido/);
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+});
+
+test("renderAnalysisHtml shows AI analysis and readable metrics", () => {
+  const html = renderAnalysisHtml({
+    success: true,
+    engine: "postgresql",
+    execution_time_ms: 12.3456,
+    plan_summary: "Seq Scan on alumnos",
+    ai_analysis: {
+      summary: "La consulta hace una lectura secuencial.",
+      observations: ["Lee la tabla alumnos."],
+      recommendations: ["Crea un indice si filtras por una columna frecuente."],
+      suggested_query: "SELECT id, nombres FROM alumnos;"
+    },
+    metrics: {
+      planning_time_ms: 7.288,
+      execution_time_ms: 1.065,
+      node_count: 1,
+      scan_nodes: [
+        {
+          "Node Type": "Seq Scan",
+          "Relation Name": "alumnos",
+          "Actual Rows": 31,
+          "Actual Total Time": 0.832,
+          "Total Cost": 11
+        }
+      ]
+    },
+    raw_plan: { Plan: { "Node Type": "Seq Scan" } }
+  });
+
+  assert.match(html, /Analisis con IA/);
+  assert.match(html, /La consulta hace una lectura secuencial/);
+  assert.match(html, /Metricas clave/);
+  assert.match(html, /Planning Time Ms/);
+  assert.match(html, /Nodos de lectura/);
+  assert.match(html, /alumnos/);
+  assert.match(html, /Ver datos tecnicos completos/);
+});
+
+test("renderAnalysisHtml shows async AI loading state before AI result arrives", () => {
+  const html = renderAnalysisHtml({
+    success: true,
+    engine: "postgresql",
+    query: "SELECT 1",
+    plan_summary: "Result"
+  });
+
+  assert.match(html, /Generando analisis con IA en segundo plano/);
+});
+
+test("profilesFromConfig returns sorted named profiles", () => {
+  assert.deepEqual(
+    profilesFromConfig({
+      prod: { engine: "postgresql", database: "query_analyzer" },
+      local: { engine: "sqlite", database: ":memory:" }
+    }),
+    [
+      { name: "local", connection: { engine: "sqlite", database: ":memory:" } },
+      { name: "prod", connection: { engine: "postgresql", database: "query_analyzer" } }
+    ]
+  );
+});
+
+test("upsertProfile preserves existing profiles", () => {
+  assert.deepEqual(
+    upsertProfile(
+      { local: { engine: "sqlite", database: ":memory:" } },
+      { name: "pg", connection: { engine: "postgresql", database: "query_analyzer" } }
+    ),
+    {
+      local: { engine: "sqlite", database: ":memory:" },
+      pg: { engine: "postgresql", database: "query_analyzer" }
+    }
+  );
+});
+
+test("defaultPortForEngine knows common engines", () => {
+  assert.equal(defaultPortForEngine("postgresql"), 5432);
+  assert.equal(defaultPortForEngine("sqlite"), undefined);
+});
+
+test("buildProfileDescription summarizes the connection", () => {
+  assert.equal(
+    buildProfileDescription({
+      name: "pg",
+      connection: {
+        engine: "postgresql",
+        host: "localhost",
+        port: 5432,
+        database: "query_analyzer"
+      }
+    }),
+    "postgresql - localhost:5432 - query_analyzer"
+  );
+});

--- a/integrations/vscode-query-analyzer/tsconfig.json
+++ b/integrations/vscode-query-analyzer/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "out",
+    "rootDir": ".",
+    "strict": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
- Add a TypeScript VS Code extension under `integrations/vscode-query-analyzer`.
- Add profile selection and creation from VS Code, with passwords stored in VS Code SecretStorage.
- Render factual query results as a readable panel with key metrics, scan nodes, AI insights, and collapsible technical details.
- Fetch AI analysis asynchronously through `/api/v1/analyzer/ai` after the factual result renders.

## Dependency
This PR is functionally enhanced by #35 because the extension uses the backend `/ai` endpoint with server-side `QA_AI_*` environment variables.

## Validation
- `npm test` in `integrations/vscode-query-analyzer` (`10 passed`)
- Manual smoke during development: API on port 8000, Extension Development Host, PostgreSQL profile, factual results first and AI result later.
